### PR TITLE
nitpicking

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -110,6 +110,8 @@
 - in `probability.v`
   + `variance` is now defined based on `covariance` 
 
+- moved `subsetP` from `functions.v` to `classical_sets.v`
+
 ### Renamed
 
 - in `derive.v`:

--- a/classical/classical_sets.v
+++ b/classical/classical_sets.v
@@ -301,6 +301,9 @@ Definition bigcup T I (P : set I) (F : I -> set T) :=
 Definition subset A B := forall t, A t -> B t.
 Local Notation "A `<=` B" := (subset A B).
 
+Lemma subsetP A B : {subset A <= B} <-> (A `<=` B).
+Proof. by split => + x => /(_ x); rewrite ?inE. Qed.
+
 Definition disj_set A B := setI A B == set0.
 
 Definition proper A B := A `<=` B /\ ~ (B `<=` A).
@@ -319,6 +322,7 @@ Arguments setMR _ _ _ _ _ /.
 Arguments setML _ _ _ _ _ /.
 Arguments fst_set _ _ _ _ /.
 Arguments snd_set _ _ _ _ /.
+Arguments subsetP {T A B}.
 
 Notation range F := [set F i | i in setT].
 Notation "[ 'set' a ]" := (set1 a) : classical_set_scope.

--- a/classical/functions.v
+++ b/classical/functions.v
@@ -258,13 +258,16 @@ HB.end.
 HB.structure Definition Inversible aT rT := {f of Inv aT rT f}.
 Notation "{ 'inv' aT >->  rT }" := (@Inversible.type aT rT) : type_scope.
 Notation "[ 'inv'  'of'  f ]" := [the {inv _ >-> _} of f : _ -> _] : form_scope.
-Definition phant_inv aT rT (f : {inv aT >-> rT}) of phantom (_ -> _) f := @inv _ _ f.
+Definition phant_inv aT rT (f : {inv aT >-> rT}) of phantom (_ -> _) f :=
+  @inv _ _ f.
 Notation "f ^-1" := (@inv _ _ f%FUN) (only printing) : fun_scope.
 Notation "f ^-1" := (@inv _ _ f%function) (only printing) : function_scope.
 Notation "f ^-1" := (@phant_inv _ _ _ (Phantom (_ -> _) f%FUN)) : fun_scope.
-Notation "f ^-1" := (@phant_inv _ _ _ (Phantom (_ -> _) f%function)) : function_scope.
+Notation "f ^-1" :=
+  (@phant_inv _ _ _ (Phantom (_ -> _) f%function)) : function_scope.
 
-HB.structure Definition InvFun aT rT A B := {f of Inv aT rT f & isFun aT rT A B f}.
+HB.structure Definition InvFun aT rT A B :=
+  {f of Inv aT rT f & isFun aT rT A B f}.
 Notation "{ 'invfun' A >-> B }" := (@InvFun.type _ _ A B) : type_scope.
 Notation "[ 'invfun'  'of'  f ]" :=
   [the {invfun _ >-> _} of f : _ -> _] : form_scope.
@@ -304,7 +307,8 @@ Notation "[ 'splitsurj'  'of'  f ]" :=
 
 HB.structure Definition SplitSurjFun aT rT A B :=
    {f of @SplitSurj aT rT A B f & @Fun _ _ A B f}.
-Notation "{ 'splitsurjfun' A >-> B }" := (@SplitSurjFun.type _ _ A B) : type_scope.
+Notation "{ 'splitsurjfun' A >-> B }" :=
+  (@SplitSurjFun.type _ _ A B) : type_scope.
 Notation "[ 'splitsurjfun'  'of'  f ]" :=
   [the {splitsurjfun _ >-> _} of f : _ -> _] : form_scope.
 
@@ -2353,9 +2357,6 @@ Lemma valLR_bijP f : set_bij A B (valLR f) <-> bijective f.
 Proof. by rewrite -sigLRfun_bijP valLRK. Qed.
 
 End Restrictions2.
-
-Lemma subsetP {T} {A B : set T} : {subset A <= B} <-> (A `<=` B).
-Proof. by split => + x => /(_ x); rewrite ?inE. Qed.
 
 Section set_bij_basic_lemmas.
 Context {aT rT : Type}.


### PR DESCRIPTION
##### Motivation for this change

mostly cosmetics (trailing/spurious spaces, small shortcuts)

##### Things done/to do

<!-- please fill in the following checklist -->
- [x] added corresponding entries in `CHANGELOG_UNRELEASED.md`

<!-- only append to minimize problems when merging/rebasing -->
<!-- consider the use of `changelog/changes.sh` from
     https://github.com/math-comp/tools to generate the changelog -->

~~- [ ] added corresponding documentation in the headers~~

<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->

##### Compatibility with MathComp 2.0

<!-- MathComp-Analysis is compatible with MathComp < 2.0 (branch `master`) and
     MathComp 2.0 ([branch `hierarchy-builder`](https://github.com/math-comp/analysis/pull/698)).

     If this PR targets `master` and if it is merged, the merged commit will also be
     cherry-picked on the branch `hierarchy-builder`.

     In this case, it would be helpful if the author of the PR also prepares a PR
     for the branch `hierarchy-builder` or at least warns maintainers with an issue
     to delegate the work. -->

<!-- use the tag TODO: HB port to record divergences between `master` and `hierarchy-builder` -->

- [ ] I added the label `TODO: HB port` to make sure someone ports this PR to
      the `hierarchy-builder` branch **or** I already opened an issue or PR (please cross reference).

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-creating-and-review-PRs) and put a milestone if possible.
